### PR TITLE
fixes cuda build error in nvidia-docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
   global:
     - ROS_DISTRO=kinetic
     - DOCKER_IMAGE=rosindustrial/yak:kinetic
-    - BEFORE_SCRIPT='catkin config -w $CATKIN_WORKSPACE --no-install'
+    - CATKIN_CONFIG='--no-install'
+    - BEFORE_SCRIPT='-DCMAKE_LIBRARY_PATH=/usr/local/nvidia/lib64/'
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+#docker build -t rosindustrial/yak:kinetic .
+FROM rosindustrial/noether-nvidia:kinetic
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	ros-kinetic-perception \
+	libopenvdb-dev \
+	ros-kinetic-interactive-markers \
+	libtbb-dev \
+	libopenexr-dev \
+	ros-kinetic-octomap-ros \
+	ros-kinetic-moveit-ros-planning-interface && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -49,4 +49,7 @@ Executing rosrun nbv_planner exploration_controller_node will execute an explora
 5. When you want to start exploration: rosrun nbv_planner exploration_controller_node 
 6. When you decide that the reconstruction is good enough: rosservice call /get_mesh
 
-
+# Build with Docker:
+```
+nvidia-docker run -v "<absolute path to your yak workspace:/yak_ws>" rosindustrial/yak:kinetic catkin build --workspace /yak_ws -DCMAKE_LIBRARY_PATH=/usr/local/nvidia/lib64/
+```

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -110,10 +110,12 @@ include_directories(
   ${CUDA_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
 )
-message("debugging")
-message("PCL_INCLUDE_DIRS: ${PCL_INCLUDE_DIRS}")
-message("CUDA_INCLUDE_DIRS: ${CUDA_INCLUDE_DIRS}")
-message("CUDA_CUDA_LIBRARY: ${CUDA_CUDA_LIBRARY}")
+
+#messages for debugging cuda libraries
+#message("debugging")
+#message("PCL_INCLUDE_DIRS: ${PCL_INCLUDE_DIRS}")
+#message("CUDA_INCLUDE_DIRS: ${CUDA_INCLUDE_DIRS}")
+#message("CUDA_CUDA_LIBRARY: ${CUDA_CUDA_LIBRARY}")
 
 set(HAVE_CUDA 1)
 #list(APPEND CUDA_NVCC_FLAGS "-arch;compute_20")


### PR DESCRIPTION
the yak package successfully builds with the nvidia-docker commands described in the README.md and accompanying Dockerfile.