### PR TITLE
Added exception handling

### DIFF
--- a/yak/src/ros/kinfu_server.cpp
+++ b/yak/src/ros/kinfu_server.cpp
@@ -22,8 +22,13 @@ namespace kfusion
         }
         ROS_INFO_STREAM("Use pose hints set to " << use_pose_hints_);
         if (use_pose_hints_) {
-          tfListener_.waitForTransform("volume_pose", "ensenso_sensor_optical_frame", ros::Time::now(), ros::Duration(0.5));
-          tfListener_.lookupTransform("volume_pose", "ensenso_sensor_optical_frame", ros::Time(0), previous_volume_to_sensor_transform_);
+            try {
+                  tfListener_.waitForTransform("volume_pose", "ensenso_sensor_optical_frame", ros::Time::now(), ros::Duration(0.5));
+                  tfListener_.lookupTransform("volume_pose", "ensenso_sensor_optical_frame", ros::Time(0), previous_volume_to_sensor_transform_);
+                 }
+            catch (tf::TransformException ex){
+                ROS_ERROR("%s", ex.what());
+            }
         }
     }
 


### PR DESCRIPTION
The previous code was terminating with an error as described in [this issue](https://github.com/AustinDeric/yak/issues/18) and [this ROS Answer question](https://answers.ros.org/question/295359/tf-has-two-or-more-unconnected-trees/) when the `volume_pose` frame was not available for finding the transform. With the proposed addition, this try-catch block showcases the required error message if `volume_pose` is not available. 
~~~
[ERROR] [1530122898.477899539, 10.817000000]: "volume_pose" passed to lookupTransform argument target_frame does not exist. 
~~~

However, it as soon as the `volume_pose` frame becomes available, it allows the node to proceed instead of terminating as per the previous case. This is similar to what has been used in the [tf tutorials](http://wiki.ros.org/tf/Tutorials/tf%20and%20Time%20%28C%2B%2B%29).