### PR TITLE
Set default weight factor to 1

### DIFF
--- a/nbv_planner/src/exploration_controller_node.cpp
+++ b/nbv_planner/src/exploration_controller_node.cpp
@@ -68,6 +68,7 @@ bool Explorer::MoveToNBVs(moveit::planning_interface::MoveGroupInterface &move_g
     volumeBoxPosConstraint.constraint_region = volume;
     volumeBoxPosConstraint.link_name = "sensor_constraint_frame";
     volumeBoxPosConstraint.header.frame_id = "base_link";
+    volumeBoxPosConstraint.weight = 1;
 
     cameraPoseConstraints.position_constraints.push_back(volumeBoxPosConstraint);
 


### PR DESCRIPTION
Hey,

I have set the default weight factor for the position constraint for the link `sensor_constraint_frame`. This is to avoid the unnecessary warning which comes up when this isn't done. 
~~~
[ WARN] [1530883644.819044064, 925.199000000]: The weight on position constraint for link 'sensor_constraint_frame' is near zero. Setting to 1.0.
~~~

The `weight` in this case, being the weighting factor for this constraint (denotes relative importance to other constraints. Closer to zero means less important) as shown in [this code](https://github.com/kunal15595/ros/blob/master/moveit/src/moveit_msgs/msg/PositionConstraint.msg).